### PR TITLE
Mapi 975

### DIFF
--- a/MASFoundation/Classes/MASConstants.h
+++ b/MASFoundation/Classes/MASConstants.h
@@ -100,7 +100,7 @@ typedef void (^MASOTPChannelSelectionBlock)(NSArray *supportedOTPChannels, MASOT
 /**
  * The Two-factor authentication with OTP Credentials (MASOTPFetchCredentialsBlock) block.
  */
-typedef void (^MASOTPCredentialsBlock)(MASOTPFetchCredentialsBlock otpBlock);
+typedef void (^MASOTPCredentialsBlock)(MASOTPFetchCredentialsBlock otpBlock, NSError *otpError);
 
 
 ///--------------------------------------
@@ -431,12 +431,13 @@ typedef NS_ENUM(NSInteger, MASFoundationErrorCode)
     //
     // OTP
     //
-    MASFoundationErrorCodeInvalidOTPChannelSelectionBlock,
-    MASFoundationErrorCodeInvalidOTPCredentialsBlock,
-    MASFoundationErrorCodeInvalidOTPProvided,
-    MASFoundationErrorCodeOTPNotProvided,
-    MASFoundationErrorCodeOTPExpired,
-    MASFoundationErrorCodeOTPRetryLimitExceeded,
+    MASFoundationErrorCodeInvalidOTPChannelSelectionBlock = 160101,
+    MASFoundationErrorCodeInvalidOTPCredentialsBlock = 160102,
+    MASFoundationErrorCodeInvalidOTPProvided = 160103,
+    MASFoundationErrorCodeOTPNotProvided = 160104,
+    MASFoundationErrorCodeOTPExpired = 160105,
+    MASFoundationErrorCodeOTPRetryLimitExceeded = 160106,
+    MASFoundationErrorCodeOTPRetryBarred = 160107,
     
     MASFoundationErrorCodeCount = -999999
 };

--- a/MASFoundation/Classes/_private_/categories/NSError+MASPrivate.h
+++ b/MASFoundation/Classes/_private_/categories/NSError+MASPrivate.h
@@ -160,6 +160,15 @@
 
 
 /**
+ * Create MASFoundationErrorDomainLocal NSError for MASFoundationErrorCodeOTPRetryBarred.
+ *
+ * @returns Returns an NSError instance with the domain MASFoundationErrorDomainLocal and
+ * error code MASFoundationErrorCodeOTPRetryBarred.
+ */
++ (NSError *)errorOTPRetryBarred:(NSString *)suspensionTime;
+
+
+/**
  *  Create MASFoundationErrorDomainLocal NSError for MASFoundationErrorCodeInvalidNSURL.
  *
  *  @return Retruns an NSError instance with the domain MASFoundationErrorDomainLocal and

--- a/MASFoundation/Classes/_private_/categories/NSError+MASPrivate.m
+++ b/MASFoundation/Classes/_private_/categories/NSError+MASPrivate.m
@@ -438,6 +438,30 @@ typedef NS_ENUM(NSInteger, MASUrlErrorCode)
 }
 
 
++ (NSError *)errorOTPRetryBarred:(NSString *)suspensionTime
+{
+    //
+    // UserInfo
+    //
+    NSMutableDictionary *userInfo = [NSMutableDictionary new];
+    
+    //
+    // Description
+    //
+    NSString *localDescription =
+    [self descriptionForFoundationErrorCode:MASFoundationErrorCodeOTPRetryBarred];
+    
+    userInfo[NSLocalizedDescriptionKey] = localDescription;
+    
+    //
+    // Suspension time
+    //
+    if(suspensionTime) userInfo[MASOTPSuspensionTimeKey] = suspensionTime;
+    
+    return [self errorForFoundationCode:MASFoundationErrorCodeOTPRetryBarred info:userInfo errorDomain:MASFoundationErrorDomainLocal];
+}
+
+
 + (NSError *)errorInvalidNSDictionary
 {
     return [self errorForFoundationCode:MASFoundationErrorCodeInvalidNSDictionary errorDomain:MASFoundationErrorDomainLocal];
@@ -776,8 +800,8 @@ typedef NS_ENUM(NSInteger, MASUrlErrorCode)
         // OTP
         //
         case MASApiErrorCodeOTPExpired: return MASFoundationErrorCodeOTPExpired;
-        case MASApiErrorCodeOTPRetryLimitExceeded:
-        case MASApiErrorCodeOTPRetryBarred: return MASFoundationErrorCodeOTPRetryLimitExceeded;
+        case MASApiErrorCodeOTPRetryLimitExceeded: return MASFoundationErrorCodeOTPRetryLimitExceeded;
+        case MASApiErrorCodeOTPRetryBarred: return MASFoundationErrorCodeOTPRetryBarred;
             
         //
         // Default
@@ -842,10 +866,11 @@ typedef NS_ENUM(NSInteger, MASUrlErrorCode)
         //
         // OTP
         //
-        case MASFoundationErrorCodeOTPNotProvided: return @"Enter the OTP.";
-        case MASFoundationErrorCodeInvalidOTPProvided: return @"Authentication failed due to invalid OTP.";
+        case MASFoundationErrorCodeOTPNotProvided: return @"Enter the OTP";
+        case MASFoundationErrorCodeInvalidOTPProvided: return @"Authentication failed due to invalid OTP";
         case MASFoundationErrorCodeOTPExpired: return @"The OTP has expired.";
         case MASFoundationErrorCodeOTPRetryLimitExceeded: return @"You have exceeded the maximum number of invalid attempts. Please try after some time.";
+        case MASFoundationErrorCodeOTPRetryBarred: return @"Your account is blocked. Try after some time.";
             
         //
         // Application

--- a/MASFoundation/Classes/_private_/services/network/MASNetworkingService.m
+++ b/MASFoundation/Classes/_private_/services/network/MASNetworkingService.m
@@ -486,8 +486,12 @@ static MASGatewayMonitorStatusBlock _gatewayStatusMonitor_;
                   [magErrorCode hasSuffix:@"144"] || [magErrorCode hasSuffix:@"145"])) {
             
             [[MASOTPService sharedService] validateOTPSessionWithResponseHeaders:headerInfo
-                completionBlock:^(NSString *oneTimePassword, NSError *error)
+                completionBlock:^(NSDictionary *responseInfo, NSError *error)
                 {
+                    
+                    NSString *oneTimePassword = [responseInfo objectForKey:MASHeaderOTPKey];
+                    NSArray *otpChannels = [responseInfo objectForKey:MASHeaderOTPChannelKey];
+                    
                     //
                     // If it fails to fetch OTP, notify user
                     //
@@ -499,6 +503,8 @@ static MASGatewayMonitorStatusBlock _gatewayStatusMonitor_;
                         
                         NSMutableDictionary *newHeader = [originalHeaderInfo mutableCopy];
                         [newHeader setObject:oneTimePassword forKey:MASHeaderOTPKey];
+                        NSString *otpSelectedChannelsStr = [otpChannels componentsJoinedByString:@","];
+                        [newHeader setObject:otpSelectedChannelsStr forKey:MASHeaderOTPChannelKey];
                         
                         //
                         // Retry request

--- a/MASFoundation/Classes/_private_/services/otp/MASOTPService.h
+++ b/MASFoundation/Classes/_private_/services/otp/MASOTPService.h
@@ -56,10 +56,9 @@
  *  This method will go through the validation process of error codes related to OTP flow.
  *
  *  @param responseHeaderInfo    the value will be an NSDictionary of key/value pairs from the HTTP response header.
- *  @param completion            An MASObjectResponseErrorBlock (id object, NSError *error) that will
- *   receive the one time password object or an NSError object if there is a failure.
+ *  @param completion            An MASResponseInfoErrorBlock (NSDictionary *responseInfo, NSError *error) that will receive the one time password object and user selected otp channels or an NSError object if there is a failure.
  */
 - (void)validateOTPSessionWithResponseHeaders:(NSDictionary *)responseHeaderInfo
-                              completionBlock:(MASObjectResponseErrorBlock)completion;
+                              completionBlock:(MASResponseInfoErrorBlock)completion;
 
 @end


### PR DESCRIPTION
The branch #MAPI-975 adds following to the iOS-MAS-Foundation.
1. Per CRUD request OTP channel caching.
2. Addition of X-OTP-Channel header with the Retry request.
3. Enhancement of OTP error codes.
