### PR TITLE
DE315173 : [FIDO][iOS] While authenticating through bio metircs, if i…

### DIFF
--- a/MASFoundation/Classes/_private_/services/model/MASModelService.m
+++ b/MASFoundation/Classes/_private_/services/model/MASModelService.m
@@ -837,6 +837,16 @@ static MASUserAuthCredentialsBlock _userAuthCredentialsBlock_ = nil;
                 //
                 [blockSelf registerDeviceWithAuthCredentials:authCredentials completion:^(BOOL completed, NSError * _Nullable error) {
                     
+                    if (error)
+                    {
+                        if (blockAuthCompletion)
+                        {
+                            blockAuthCompletion(NO, error);
+                        }
+                        
+                        return;
+                    }
+                    
                     if (blockAuthCredentials.isReuseable)
                     {
                         [blockSelf loginWithAuthCredentials:blockAuthCredentials completion:^(BOOL completed, NSError * _Nullable error) {
@@ -873,16 +883,6 @@ static MASUserAuthCredentialsBlock _userAuthCredentialsBlock_ = nil;
                         //  Clear credentials after first attempt if it is not reuseable
                         //
                         [blockAuthCredentials clearCredentials];
-                        
-                        if (error)
-                        {
-                            if (blockAuthCompletion)
-                            {
-                                blockAuthCompletion(NO, error);
-                            }
-                            
-                            return;
-                        }
                         
                         if (blockCompletion)
                         {


### PR DESCRIPTION
…t fails to login due to unavailable of Authenticator Metadata, app throws "This device is not registered" error