### PR TITLE
DE359604 : [iOS][MASFoundation] [MAS setGatewayNetworkActivityLogging…

### DIFF
--- a/MASFoundation/Classes/MAS.m
+++ b/MASFoundation/Classes/MAS.m
@@ -152,14 +152,10 @@
 }
 
 
-#ifdef DEBUG
-
 + (void)setGatewayNetworkActivityLogging:(BOOL)enabled
 {
     [MASNetworkingService setGatewayNetworkActivityLogging:enabled];
 }
-
-#endif
 
 
 # pragma mark - Start & Stop

--- a/MASFoundation/Classes/_private_/services/network/MASNetworkingService.h
+++ b/MASFoundation/Classes/_private_/services/network/MASNetworkingService.h
@@ -99,8 +99,6 @@ typedef NSURLRequest* (^MASSessionDataTaskHTTPRedirectBlock)(NSURLSession *sessi
 
 
 
-#ifdef DEBUG
-
 /**
  *  Debug property to view the network REST calls requests/responses on the console.
  *  Default is NO.
@@ -108,8 +106,6 @@ typedef NSURLRequest* (^MASSessionDataTaskHTTPRedirectBlock)(NSURLSession *sessi
  *  @param enabled YES to log network activity, NO to not.
  */
 + (void)setGatewayNetworkActivityLogging:(BOOL)enabled;
-
-#endif
 
 
 

--- a/MASFoundation/Classes/_private_/services/network/MASNetworkingService.m
+++ b/MASFoundation/Classes/_private_/services/network/MASNetworkingService.m
@@ -179,8 +179,6 @@ static NSMutableDictionary *_reachabilityMonitoringBlockForHosts_;
 }
 
 
-#ifdef DEBUG
-
 # pragma mark - DEBUG
 
 + (void)setGatewayNetworkActivityLogging:(BOOL)enabled
@@ -203,8 +201,6 @@ static NSMutableDictionary *_reachabilityMonitoringBlockForHosts_;
         [[MASNetworkMonitor sharedMonitor] stopMonitoring];
     }
 }
-
-#endif
 
 
 # pragma mark - Shared Service


### PR DESCRIPTION
…:] method causes crash when deploying to the device