### PR TITLE
DE374443 : [Cordova v1.7.10][iOS] App throws an error "id_token does …

### DIFF
--- a/MASFoundation/Classes/_private_/services/access/MASAccessService.m
+++ b/MASFoundation/Classes/_private_/services/access/MASAccessService.m
@@ -910,6 +910,11 @@ static BOOL _isKeychainSynchronizable_ = NO;
 
 - (BOOL)lockSession:(NSError * __nullable __autoreleasing * __nullable)error
 {
+    //
+    // Refresh the currentAccessObj to reflect the current status
+    //
+    [[MASAccessService sharedService].currentAccessObj refresh];
+    
     NSError *localError = nil;
     BOOL success = NO;
     
@@ -1009,6 +1014,11 @@ static BOOL _isKeychainSynchronizable_ = NO;
 
 - (BOOL)unlockSessionWithUserOperationPromptMessage:(NSString *)userOperationPrompt error:(NSError * __nullable __autoreleasing * __nullable)error
 {
+    //
+    // Refresh the currentAccessObj to reflect the current status
+    //
+    [[MASAccessService sharedService].currentAccessObj refresh];
+    
     NSError *localError = nil;
     NSString *idToken = nil;
     


### PR DESCRIPTION
…not exist; id_token is required for locking the session" while locking the screen