### PR TITLE
[BUGFIX] Crash client

### DIFF
--- a/MASFoundation/Vendor/MASIOrderedDictionary/MASIOrderedDictionary.m
+++ b/MASFoundation/Vendor/MASIOrderedDictionary/MASIOrderedDictionary.m
@@ -325,7 +325,7 @@
     {
         _mutableValues[index] = object;
     }
-    else
+    else if (object)
     {
         [_mutableKeys addObject:key];
         [_mutableValues addObject:object];


### PR DESCRIPTION
When using `[MASDevice resetLocally]()`  in some situations, the app result in a crash as the follow stack trace
```
Last Exception Backtrace (0)

#5	(null) in -[MASIMutableOrderedDictionary setObject:forKey:] ()
#6	(null) in -[MASIMutableOrderedDictionary setObject:forKeyedSubscript:] ()
#7	(null) in -[MASModelService retrieveAuthenticationProviders:] ()
#8	(null) in __46-[MASModelService validateCurrentUserSession:]_block_invoke ()
#9	(null) in -[MASModelService registerApplication:] ()
#10	(null) in -[MASModelService validateCurrentUserSession:] ()
#11	(null) in -[MASAuthValidationOperation validateAuthSession] ()

 Thread 1
#14	(null) in -[MASIKeyChainStore dataForKey:error:] ()
#15	(null) in -[MASAccessService getAccessValueDataWithStorageKey:error:] ()
#16	(null) in -[MASAccessService getAccessValueNumberWithStorageKey:] ()
#17	(null) in -[MASAccess refresh] ()
#18	(null) in -[MASDevice resetLocally] ()
```

In some situations the Client_id is coming nil resulting in a crash for the application
```
Key : Client_id 
Object: nil
```
