### PR TITLE
Fix ID token check

### DIFF
--- a/MASFoundation/Classes/models/MASApplication.m
+++ b/MASFoundation/Classes/models/MASApplication.m
@@ -161,17 +161,11 @@ static NSString *const MASApplicationStatusPropertyKey = @"status"; // string
     
 
     //
-    // If there is an idToken and a current user
+    // If there is a valid idToken and a current user
     //
-    if(idToken && currentUser)
+    if(idToken && ![MASAccessService isIdTokenExpired:idToken error:nil] && currentUser)
     {
-        //
-        // Check idToken expiration
-        //
-        if(![MASAccessService isIdTokenExpired:idToken error:nil])
-        {
-            currentStatus = MASAuthenticationStatusLoginWithUser;
-        }
+        currentStatus = MASAuthenticationStatusLoginWithUser;
     }
     else {
         //


### PR DESCRIPTION
## Issue
The method `MASApplication.authenticationStatus` returns a false negative when an ID token is present but expired. This causes unnecessary calls to refresh endpoints in `MASModelService.loginUsingCredentials` since it believes the user is not logged in. Further, it causes `MASUser.logout` to return with error without clearing data.

## Steps to Reproduce
1. Allow the ID token to expire while maintaining a valid refresh token.
2. Observe that all subsequent API calls refresh the access token, even if a valid one is present.
3. Observe that calls to `MASUser.logout` return with error without clearing data, despite a valid refresh token (and potentially access token), and persistent user information.

## Changes
This MR changes the logic of `MASApplication.authenticationStatus` to check for other token types to be present when the ID token is present but expired.