### PR TITLE
Changed the response type to plain text for certificate renewal service

### DIFF
--- a/MASFoundation/Classes/_private_/services/model/MASModelService.m
+++ b/MASFoundation/Classes/_private_/services/model/MASModelService.m
@@ -1097,9 +1097,7 @@ static BOOL _isBrowserBasedAuthentication_ = NO;
     //
     __block MASModelService *blockSelf = self;
     __block MASCompletionErrorBlock blockCompletion = completion;
-    [[MASNetworkingService sharedService] putTo:endPoint
-                                 withParameters:nil
-                                     andHeaders:headerInfo
+    [[MASNetworkingService sharedService] putTo:endPoint withParameters:nil andHeaders:headerInfo requestType:MASRequestResponseTypeJson responseType:MASRequestResponseTypeTextPlain
                                      completion:^(NSDictionary *responseInfo, NSError *error) {
                                         
                                          //

--- a/MASFoundation/Classes/_private_/services/model/MASModelService.m
+++ b/MASFoundation/Classes/_private_/services/model/MASModelService.m
@@ -434,7 +434,9 @@ static BOOL _isBrowserBasedAuthentication_ = NO;
     MASIMutableOrderedDictionary *parameterInfo = [MASIMutableOrderedDictionary new];
     
     // ClientId
-    parameterInfo[MASClientKeyRequestResponseKey] = [[MASAccessService sharedService] getAccessValueStringWithStorageKey:MASKeychainStorageKeyClientId];
+       if ([[MASAccessService sharedService] getAccessValueStringWithStorageKey:MASKeychainStorageKeyClientId]) {
+           parameterInfo[MASClientKeyRequestResponseKey] = [[MASAccessService sharedService] getAccessValueStringWithStorageKey:MASKeychainStorageKeyClientId];
+       }
     
     // RedirectUri
     parameterInfo[MASRedirectUriRequestResponseKey] = [[MASApplication currentApplication].redirectUri absoluteString];

--- a/MASFoundation/Classes/_private_/services/network/MASNetworkingService.m
+++ b/MASFoundation/Classes/_private_/services/network/MASNetworkingService.m
@@ -657,6 +657,7 @@ static NSMutableArray *_multiFactorAuthenticators_;
         //
         else if (magErrorCode && [magErrorCode hasSuffix:@"206"] && ![blockEndPoint isEqualToString:[MASConfiguration currentConfiguration].deviceRenewEndpointPath])
         {
+            [_sessionManager.operationQueue setSuspended:YES];
             //
             // Renew the client certificate, if the renew endpoint fails,
             //
@@ -1444,11 +1445,17 @@ withParameters:(NSDictionary *)parameterInfo
     //
     // Default types
     //
+    NSInteger responseType;
+    if ([endPoint  isEqual: @"/connect/device/renew"]) {
+        responseType = MASRequestResponseTypeTextPlain;
+    } else {
+        responseType = MASRequestResponseTypeJson;
+    }
     [self putTo:endPoint
  withParameters:parameterInfo
      andHeaders:headerInfo
     requestType:MASRequestResponseTypeJson
-   responseType:MASRequestResponseTypeJson
+   responseType:responseType
        isPublic:NO
 timeoutInterval:MASDefaultNetworkTimeoutConfiguration
      completion:completion];

--- a/MASFoundation/Classes/_private_/services/network/MASNetworkingService.m
+++ b/MASFoundation/Classes/_private_/services/network/MASNetworkingService.m
@@ -1445,17 +1445,11 @@ withParameters:(NSDictionary *)parameterInfo
     //
     // Default types
     //
-    NSInteger responseType;
-    if ([endPoint  isEqual: @"/connect/device/renew"]) {
-        responseType = MASRequestResponseTypeTextPlain;
-    } else {
-        responseType = MASRequestResponseTypeJson;
-    }
     [self putTo:endPoint
  withParameters:parameterInfo
      andHeaders:headerInfo
     requestType:MASRequestResponseTypeJson
-   responseType:responseType
+   responseType:MASRequestResponseTypeJson
        isPublic:NO
 timeoutInterval:MASDefaultNetworkTimeoutConfiguration
      completion:completion];

--- a/MASFoundation/Classes/models/MASApplication.m
+++ b/MASFoundation/Classes/models/MASApplication.m
@@ -165,12 +165,14 @@ static NSString *const MASApplicationStatusPropertyKey = @"status"; // string
     //
     if(idToken && currentUser)
     {
-        //
-        // Check idToken expiration
-        //
-        if(![MASAccessService isIdTokenExpired:idToken error:nil])
-        {
-            currentStatus = MASAuthenticationStatusLoginWithUser;
+        if(idToken && ![MASAccessService isIdTokenExpired:idToken error:nil] && currentUser) {
+            //
+            // Check idToken expiration
+            //
+            if(![MASAccessService isIdTokenExpired:idToken error:nil])
+            {
+                currentStatus = MASAuthenticationStatusLoginWithUser;
+            }
         }
     }
     else {

--- a/MASFoundation/Classes/models/MASApplication.m
+++ b/MASFoundation/Classes/models/MASApplication.m
@@ -161,19 +161,11 @@ static NSString *const MASApplicationStatusPropertyKey = @"status"; // string
     
 
     //
-    // If there is an idToken and a current user
+    // If there is a valid idToken and a current user
     //
-    if(idToken && currentUser)
+    if(idToken && ![MASAccessService isIdTokenExpired:idToken error:nil] && currentUser)
     {
-        if(idToken && ![MASAccessService isIdTokenExpired:idToken error:nil] && currentUser) {
-            //
-            // Check idToken expiration
-            //
-            if(![MASAccessService isIdTokenExpired:idToken error:nil])
-            {
-                currentStatus = MASAuthenticationStatusLoginWithUser;
-            }
-        }
+        currentStatus = MASAuthenticationStatusLoginWithUser;
     }
     else {
         //


### PR DESCRIPTION
-> Response type is made dynamic
-> Error 206 is been handled correctly
-> Ensured that devices can renew certificate if expired.