### PR TITLE
Authentication Providers Retrieval

### DIFF
--- a/MASFoundation/Classes/_private_/services/model/MASModelService.h
+++ b/MASFoundation/Classes/_private_/services/model/MASModelService.h
@@ -130,6 +130,10 @@
  */
 - (void)retrieveEnterpriseApplications:(MASObjectsResponseErrorBlock)completion;
 
+/**
+ *  Clears the cached auth providers.
+ */
+- (void)resetAuthProviders;
 
 
 ///--------------------------------------

--- a/MASFoundation/Classes/_private_/services/model/MASModelService.m
+++ b/MASFoundation/Classes/_private_/services/model/MASModelService.m
@@ -402,9 +402,18 @@ static BOOL _isBrowserBasedAuthentication_ = NO;
 {
     
     //
-    // If the user was already authenticated, we don't have to retrieve the authentication provider
+    // If the authentication providers have already been retrieved, we don't have to retrieve them
     //
-    if (([MASApplication currentApplication].isAuthenticated && [MASApplication currentApplication].authenticationStatus == MASAuthenticationStatusLoginWithUser) || [MASAccess currentAccess].isSessionLocked || _isBrowserBasedAuthentication_)
+    if (_currentProviders)
+    {
+        if (completion)
+        {
+            completion(_currentProviders, nil);
+        }
+        return;
+    }
+    
+    if ([MASAccess currentAccess].isSessionLocked || _isBrowserBasedAuthentication_)
     {
         //
         // Notify

--- a/MASFoundation/Classes/_private_/services/model/MASModelService.m
+++ b/MASFoundation/Classes/_private_/services/model/MASModelService.m
@@ -189,13 +189,9 @@ static BOOL _isBrowserBasedAuthentication_ = NO;
 - (void)serviceDidReset
 {
     //
-    // If the current providers exists
+    // Reset auth providers
     //
-    if (self.currentProviders)
-    {
-        [self.currentProviders reset];
-        _currentProviders = nil;
-    }
+    [self resetAuthProviders];
     
     //
     // If the current user exists
@@ -225,6 +221,15 @@ static BOOL _isBrowserBasedAuthentication_ = NO;
     }
     
     [super serviceDidReset];
+}
+
+- (void)resetAuthProviders
+{
+    if (self.currentProviders)
+    {
+        [self.currentProviders reset];
+        _currentProviders = nil;
+    }
 }
 
 
@@ -1249,6 +1254,11 @@ static BOOL _isBrowserBasedAuthentication_ = NO;
 - (void)logoutDevice:(BOOL)force completion:(MASCompletionErrorBlock)completion
 {
     
+    //
+    // Reset auth providers
+    //
+    [self resetAuthProviders];
+    
     MASAccessService *accessService = [MASAccessService sharedService];
     
     //
@@ -2085,6 +2095,11 @@ static BOOL _isBrowserBasedAuthentication_ = NO;
  */
 - (void)logout:(BOOL)force completion:(MASCompletionErrorBlock)completion
 {
+    //
+    // Reset auth providers
+    //
+    [self resetAuthProviders];
+    
     //
     // The application must be registered else stop here
     //

--- a/MASFoundation/Classes/_private_/services/model/MASModelService.m
+++ b/MASFoundation/Classes/_private_/services/model/MASModelService.m
@@ -1253,12 +1253,6 @@ static BOOL _isBrowserBasedAuthentication_ = NO;
 
 - (void)logoutDevice:(BOOL)force completion:(MASCompletionErrorBlock)completion
 {
-    
-    //
-    // Reset auth providers
-    //
-    [self resetAuthProviders];
-    
     MASAccessService *accessService = [MASAccessService sharedService];
     
     //
@@ -2095,11 +2089,6 @@ static BOOL _isBrowserBasedAuthentication_ = NO;
  */
 - (void)logout:(BOOL)force completion:(MASCompletionErrorBlock)completion
 {
-    //
-    // Reset auth providers
-    //
-    [self resetAuthProviders];
-    
     //
     // The application must be registered else stop here
     //

--- a/MASFoundation/Classes/models/MASUser.m
+++ b/MASFoundation/Classes/models/MASUser.m
@@ -225,6 +225,10 @@ static NSString *const MASUserAttributesPropertyKey = @"attributes";
 
 - (void)logout:(BOOL)force completion:(MASCompletionErrorBlock)completion
 {
+    //
+    // Reset auth providers
+    //
+    [[MASModelService sharedService] resetAuthProviders];
     
     MASAccessService *accessService = [MASAccessService sharedService];
     


### PR DESCRIPTION
## Issue
The `retrieveAuthenticationProviders` function downloads authentication providers from the gateway, when necessary. The problem is that "when necessary" is not defined well and leads to excessive calls to the server.

## Steps to Reproduce
1. Obtain access token, refresh token, and ID token.
2. Let ID token expire.
3. Observe 2 calls made to the authentication providers endpoint on every subsequent token refresh.
> This is best observed by uncommenting line 419 in [MASModelService.m](https://github.com/CAAPIM/iOS-MAS-Foundation/blob/e055e6c4339dd8bc3a8fca43e991eca13889e16b/MASFoundation/Classes/_private_/services/model/MASModelService.m#L419)

## Proposed Fix
Since the authentication providers are cached on the first call to the endpoint, they do not need to be retrieved again unless the user is logged out or the SDK is reinitialized. As they are already cleared in either scenario, the following code will prevent making redundant calls.

```objc
if (_currentProviders)
{
  if (completion)
  {
    completion(_currentProviders, nil);
  }
  return;
}
```