### PR TITLE
[DE490325/DE501977] Unnecessary calls to authproviders as the refresh…

### DIFF
--- a/MASFoundation/Classes/_private_/services/model/MASModelService.m
+++ b/MASFoundation/Classes/_private_/services/model/MASModelService.m
@@ -419,6 +419,21 @@ static BOOL _isBrowserBasedAuthentication_ = NO;
     //DLog(@"\n\nNO detected cached providers, retreiving from server\n\n");
 
     //
+    // If authentication providers are already fetched just use them.
+    // DE490325/DE501977 - Extra calls to auth providers
+    //
+    if (_currentProviders) {
+        
+        if (completion) {
+            
+            completion(_currentProviders, nil);
+        }
+        
+        return;
+    }
+    
+    
+    //
     // Endpoint
     //
     NSString *endPoint = [MASConfiguration currentConfiguration].authorizationEndpointPath;


### PR DESCRIPTION
…token login again fetch authproviders, so put a check if authproviders object exists do not fetch again