### PR TITLE
Feature/f114908 - Moving Codeverifier and State values into keychain.

### DIFF
--- a/MASFoundation/Classes/_private_/models/MASAccess.m
+++ b/MASFoundation/Classes/_private_/models/MASAccess.m
@@ -429,7 +429,6 @@
 {
     if ([MASAccessService isPKCEEnabled])
     {
-//        _codeVerifier = [NSString randomStringWithLength:43];
         [[MASAccessService sharedService] setAccessValueString:
          [NSString randomStringWithLength:43] storageKey:MASKeychainStorageKeyCodeVerifier];
     }
@@ -438,14 +437,12 @@
 
 - (void)deleteCodeVerifier
 {
-//    _codeVerifier = nil;
     [[MASAccessService sharedService] setAccessValueString:nil storageKey:MASKeychainStorageKeyCodeVerifier];
 }
 
 
 - (NSString *)retrieveCodeVerifier
 {
-//    return [MASAccessService isPKCEEnabled] ? _codeVerifier : nil;
     return [MASAccessService isPKCEEnabled] ?
     [[MASAccessService sharedService] getAccessValueStringWithStorageKey:MASKeychainStorageKeyCodeVerifier] : nil;
 }
@@ -461,23 +458,20 @@
 {
     if ([MASAccessService isPKCEEnabled])
     {
-        //_pkceState = [NSString randomStringWithLength:32];
         [[MASAccessService sharedService] setAccessValueString:
-         [NSString randomStringWithLength:43] storageKey:MASKeychainStorageKeyPKCEState];
+         [NSString randomStringWithLength:32] storageKey:MASKeychainStorageKeyPKCEState];
     }
 }
 
 
 - (void)deletePKCEState
 {
-//    _pkceState = nil;
     [[MASAccessService sharedService] setAccessValueString:nil storageKey:MASKeychainStorageKeyPKCEState];
 }
 
 
 - (NSString *)retrievePKCEState
 {
-//    return [MASAccessService isPKCEEnabled] ? _pkceState : nil;
     return [MASAccessService isPKCEEnabled] ? [[MASAccessService sharedService] getAccessValueStringWithStorageKey:MASKeychainStorageKeyPKCEState] : nil;
 }
 

--- a/MASFoundation/Classes/_private_/models/MASAccess.m
+++ b/MASFoundation/Classes/_private_/models/MASAccess.m
@@ -18,8 +18,8 @@
 
 @interface MASAccess ()
 
-@property (nonatomic, strong) NSString *codeVerifier;
-@property (nonatomic, strong) NSString *pkceState;
+//@property (nonatomic, strong) NSString *codeVerifier;
+//@property (nonatomic, strong) NSString *pkceState;
 
 @end
 
@@ -429,20 +429,25 @@
 {
     if ([MASAccessService isPKCEEnabled])
     {
-        _codeVerifier = [NSString randomStringWithLength:43];
+//        _codeVerifier = [NSString randomStringWithLength:43];
+        [[MASAccessService sharedService] setAccessValueString:
+         [NSString randomStringWithLength:43] storageKey:MASKeychainStorageKeyCodeVerifier];
     }
 }
 
 
 - (void)deleteCodeVerifier
 {
-    _codeVerifier = nil;
+//    _codeVerifier = nil;
+    [[MASAccessService sharedService] setAccessValueString:nil storageKey:MASKeychainStorageKeyCodeVerifier];
 }
 
 
 - (NSString *)retrieveCodeVerifier
 {
-    return [MASAccessService isPKCEEnabled] ? _codeVerifier : nil;
+//    return [MASAccessService isPKCEEnabled] ? _codeVerifier : nil;
+    return [MASAccessService isPKCEEnabled] ?
+    [[MASAccessService sharedService] getAccessValueStringWithStorageKey:MASKeychainStorageKeyCodeVerifier] : nil;
 }
 
 
@@ -456,20 +461,24 @@
 {
     if ([MASAccessService isPKCEEnabled])
     {
-        _pkceState = [NSString randomStringWithLength:32];
+        //_pkceState = [NSString randomStringWithLength:32];
+        [[MASAccessService sharedService] setAccessValueString:
+         [NSString randomStringWithLength:43] storageKey:MASKeychainStorageKeyPKCEState];
     }
 }
 
 
 - (void)deletePKCEState
 {
-    _pkceState = nil;
+//    _pkceState = nil;
+    [[MASAccessService sharedService] setAccessValueString:nil storageKey:MASKeychainStorageKeyPKCEState];
 }
 
 
 - (NSString *)retrievePKCEState
 {
-    return [MASAccessService isPKCEEnabled] ? _pkceState : nil;
+//    return [MASAccessService isPKCEEnabled] ? _pkceState : nil;
+    return [MASAccessService isPKCEEnabled] ? [[MASAccessService sharedService] getAccessValueStringWithStorageKey:MASKeychainStorageKeyPKCEState] : nil;
 }
 
 

--- a/MASFoundation/Classes/_private_/services/access/MASAccessService.h
+++ b/MASFoundation/Classes/_private_/services/access/MASAccessService.h
@@ -48,6 +48,8 @@ extern NSString * const MASKeychainStorageKeyIsDeviceLocked;
 extern NSString * const MASKeychainStorageKeyCurrentAuthCredentialsGrantType;
 extern NSString * const MASKeychainStorageKeyMASUserObjectData;
 extern NSString * const MASKeychainStorageKeyDeviceVendorId;
+extern NSString * const MASKeychainStorageKeyCodeVerifier;
+extern NSString * const MASKeychainStorageKeyPKCEState;
 
 
 /**

--- a/MASFoundation/Classes/_private_/services/access/MASAccessService.m
+++ b/MASFoundation/Classes/_private_/services/access/MASAccessService.m
@@ -61,6 +61,8 @@ NSString * const MASKeychainStorageKeyCurrentAuthCredentialsGrantType = @"kMASAc
 NSString * const MASKeychainStorageKeyMASUserObjectData = @"kMASAccessValueTypeMASUserObjectData";
 NSString * const MASKeychainStorageKeyDeviceVendorId = @"kMASKeyChainDeviceVendorId";
 NSString * const MASKeychainStorageKeyBundleIdentifiers = @"kMASKeychainStorageKeyBundleIdentifiers";
+NSString * const MASKeychainStorageKeyCodeVerifier = @"kMASKeychainStorageKeyCodeVerifier";
+NSString * const MASKeychainStorageKeyPKCEState = @"kMASKeychainStorageKeyPKCEState";
 
 
 @interface MASAccessService ()


### PR DESCRIPTION
Issue:
Presently Code verifier is getting generated and stored in Memory cache. When mobile app which is built using SDK calls another external app for authentication, it goes to background. In some cases, it is getting killed by the OS. Due to this, code verifier, which is stored in memory cache is getting lost.

Fix:
Moving the Codeverifier and State values from private properties to keychain storage.