### PR TITLE
[US787228] cancelAllRequests removes observer for operationque which …

### DIFF
--- a/MASFoundation/Classes/_private_/services/network/MASNetworkingService.m
+++ b/MASFoundation/Classes/_private_/services/network/MASNetworkingService.m
@@ -1894,8 +1894,6 @@ timeoutInterval:(NSTimeInterval)timeoutInterval
     NSLog(@"Cancel All Requests");
     [[_sessionManager operationQueue] cancelAllOperations];
     [[_sessionManager internalOperationQueue] cancelAllOperations];
-    [[_sessionManager operationQueue] removeObserver:self forKeyPath:@"operations" context:&kMASNetworkQueueOperationsChanged];
-
 }
 
 


### PR DESCRIPTION
…can still be used and may lead to unnecessary crash upon MAS stop